### PR TITLE
Error on debugger

### DIFF
--- a/src/protocol.c
+++ b/src/protocol.c
@@ -14,7 +14,7 @@ void debug_write_packet(uint8_t* buf, int len, int loginToClient)
     int i = 0;
     int j, k;
 
-    printf("%llu ", time(NULL));
+    printf("%ld ", time(NULL));
     if (loginToClient)
         printf("LOGIN to CLIENT (len %i):\n", len);
     else


### PR DESCRIPTION
I had an error on while trying to debug the connection and it said it was due to the long long unsigned int. This data type for printf() fixes this.